### PR TITLE
Remove deprecated version key from docker compose files

### DIFF
--- a/speechtrap/docker-compose.prod.yml
+++ b/speechtrap/docker-compose.prod.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   db:
     image: postgres:15

--- a/speechtrap/docker-compose.yml
+++ b/speechtrap/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   db:
     image: postgres:15


### PR DESCRIPTION
## Summary
- remove obsolete version key from development and production docker-compose files to silence warnings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935aa88f7988333bc56bdd9226023bb)