### PR TITLE
Ensure frontend node_modules persists in docker compose

### DIFF
--- a/speechtrap/docker-compose.yml
+++ b/speechtrap/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     command: npm run dev -- --host 0.0.0.0 --port 5173
     volumes:
       - ./frontend:/app
+      - /app/node_modules
     depends_on:
       - backend
     ports:


### PR DESCRIPTION
## Summary
- mount an anonymous volume for frontend node_modules so development dependencies remain available when bind mounting the source

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935b2920ddc8333aa6282f23e64f642)