### PR TITLE
Add interactive lobby actions and API feedback

### DIFF
--- a/speechtrap/frontend/src/components/LobbyCard.tsx
+++ b/speechtrap/frontend/src/components/LobbyCard.tsx
@@ -4,9 +4,11 @@ interface LobbyCardProps {
   title: string
   description: string
   buttonText: string
+  onClick?: () => void
+  isLoading?: boolean
 }
 
-export function LobbyCard({ title, description, buttonText }: LobbyCardProps) {
+export function LobbyCard({ title, description, buttonText, onClick, isLoading }: LobbyCardProps) {
   return (
     <div className="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 shadow-lg shadow-purple-500/10">
       <div className="flex items-center justify-between">
@@ -14,8 +16,13 @@ export function LobbyCard({ title, description, buttonText }: LobbyCardProps) {
           <h3 className="text-xl font-semibold">{title}</h3>
           <p className="mt-1 text-slate-300">{description}</p>
         </div>
-        <button className="inline-flex items-center gap-2 rounded-full bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-purple-500/30 transition hover:bg-purple-500">
-          {buttonText}
+        <button
+          className="inline-flex items-center gap-2 rounded-full bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-purple-500/30 transition hover:bg-purple-500 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={onClick}
+          disabled={!onClick || isLoading}
+          type="button"
+        >
+          {isLoading ? 'Обработка...' : buttonText}
           <ArrowRight />
         </button>
       </div>


### PR DESCRIPTION
## Summary
- wire lobby action buttons to backend endpoints for creating rooms, joining by code, and viewing profile hints
- add inline activity log to surface live API responses and button loading states
- harden UI buttons with disabled states and clearer feedback during actions

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935d0b0e91c83338be49b640cc48de1)