### PR TITLE
Fix diacritic stripping for answer handling

### DIFF
--- a/serbian-duo/app.js
+++ b/serbian-duo/app.js
@@ -405,11 +405,16 @@ function shuffle(array) {
 }
 
 function normalize(value) {
-  return value.normalize('NFD').replace(/\p{Diacritic}/gu, '').trim().toLowerCase();
+  if (!value) return '';
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase();
 }
 
 function matchesAnswer(answer, target) {
-  return normalize(target) === answer;
+  return normalize(target) === normalize(answer);
 }
 
 function feedback(message, tone = 'success') {


### PR DESCRIPTION
## Summary
- replace Unicode property-based diacritic removal with a broadly supported combining-mark strip
- normalize both expected and provided answers to avoid platform regex parse issues

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a80b6717c83339b678836e06f5448)